### PR TITLE
Add standalone git deployer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # sync
-sync to server
+
+This repository contains a simple standalone script for deploying code using Git.
+
+## git_deployer.sh
+
+`git_deployer.sh` is a helper script that clones or updates a repository in a target directory. It can be used on a server to keep a working copy in sync with a remote Git repository.
+
+### Usage
+
+```bash
+./git_deployer.sh <repo-url> [target-dir] [branch]
+```
+
+- `repo-url`: URL of the Git repository to deploy.
+- `target-dir`: Optional directory where the repository should be cloned or updated. Defaults to the repository name.
+- `branch`: Optional branch to deploy. Defaults to `main`.
+
+The script will clone the repository if the target directory does not exist. If it exists and contains a Git repository, it will fetch and pull the specified branch.

--- a/git_deployer.sh
+++ b/git_deployer.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# git_deployer.sh - Standalone Git deployment script
+# Usage: ./git_deployer.sh <repo-url> [target-dir] [branch]
+# Clones or updates a repository in the target directory.
+
+set -e
+
+REPO_URL="$1"
+TARGET_DIR="${2:-$(basename "$REPO_URL" .git)}"
+BRANCH="${3:-main}"
+
+if [ -z "$REPO_URL" ]; then
+  echo "Usage: $0 <repo-url> [target-dir] [branch]" >&2
+  exit 1
+fi
+
+if [ ! -d "$TARGET_DIR/.git" ]; then
+  echo "Cloning $REPO_URL into $TARGET_DIR"
+  git clone --branch "$BRANCH" "$REPO_URL" "$TARGET_DIR"
+else
+  echo "Updating existing repo in $TARGET_DIR"
+  cd "$TARGET_DIR"
+  git fetch origin
+  git checkout "$BRANCH"
+  git pull origin "$BRANCH"
+fi
+


### PR DESCRIPTION
## Summary
- add a standalone `git_deployer.sh` script for updating/cloning repos
- expand README with instructions for using the deployer

## Testing
- `bash -n git_deployer.sh`